### PR TITLE
Corrected the bower main script file path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "victorjonsson"
   ],
   "description": "With this feature rich jQuery plugin it becomes easy to validate user input while keeping your HTML markup clean from javascript code. Even though this plugin has a wide range of validation functions it's designed to require as little bandwidth as possible. This is achieved by grouping together validation functions in \"modules\", making it possible for the programmer to load only those functions that's needed to validate a particular form.",
-  "main": "jquery.form-validator.min.js",
+  "main": "./form-validator/jquery.form-validator.min.js",
   "keywords": [
     "form",
     "validator",


### PR DESCRIPTION
When using a build tool I can't automatically resolve the main file using the bower manifest because the "main" entry points to a non-existing file in the root. I suggest correcting it to point to ./form-validator/xx.js where it actually resides. Not sure why it's like it is right now..
